### PR TITLE
[Fix][kubectl-plugin] make tests use a temporary kube config

### DIFF
--- a/docs/development/development.md
+++ b/docs/development/development.md
@@ -14,12 +14,20 @@ The KubeRay APIServer is a central component that exposes the KubeRay API for ma
 For more information about developing and testing the KubeRay APIServer, please refer to the [APIServer Development Guide](https://github.com/ray-project/kuberay/blob/master/apiserver/DEVELOPMENT.md).
 
 ## KubeRay Python client
+
 The KubeRay Python client library provides APIs to handle RayCluster from your Python application. For more information about developing and testing the KubeRay Python client, please refer to the [Python Client](https://github.com/ray-project/kuberay/blob/master/components/pythonclient.md), [Python API Client](https://github.com/ray-project/kuberay/blob/master/components/pythonapiclient.md).
 
 ## Proto and OpenAPI
 
 KubeRay uses Protocol Buffers (protobuf) and OpenAPI specifications to define the API and data structures.
 For more information about developing and testing proto files and OpenAPI specifications, please refer to the [Proto and OpenAPI Development Guide](https://github.com/ray-project/kuberay/blob/master/proto/README.md).
+
+## KubeRay Kubectl Plugin (beta)
+
+A [kubectl plugin] that simplifies common workflows when deploying Ray on Kubernetes. If
+you aren't familiar with Kubernetes, this plugin simplifies running Ray on Kubernetes.
+For more information about developing and testing the KubeRay Kubectl Plugin, please refer to the
+[Kubectl Plugin Development Guide].
 
 ## Deploying Documentation Locally
 
@@ -36,3 +44,6 @@ docker run --rm -it -p 8000:8000 -v ${PWD}:/docs squidfunk/mkdocs-material
 - Open your web browser and navigate to <http://127.0.0.1:8000/kuberay/> to view the documentation.
 
 If you make any changes to the documentation files, the local preview will automatically update to reflect those changes.
+
+[kubectl plugin]: https://kubernetes.io/docs/tasks/extend-kubectl/kubectl-plugins/
+[Kubectl Plugin Development Guide]:

--- a/kubectl-plugin/DEVELOPMENT.md
+++ b/kubectl-plugin/DEVELOPMENT.md
@@ -1,0 +1,57 @@
+# Development
+
+This section walks through how to build and test the plugin.
+
+## Requirements
+
+| software | version | link                         |
+|:---------|:--------|:-----------------------------|
+| kubectl  |  ????   | [download][download-kubectl] |
+| go       |  v1.22  | [download-go]                |
+
+## IDE Setup (VS Code)
+
+1. Install the [VS Code Go extension]
+1. Import the KubeRay workspace configuration by using the file `kuberay.code-workspace` in the root
+   of the KubeRay git repo: "File" -> "Open Workspace from File" -> "kuberay.code-workspace".
+
+Setting up workspace configuration is required because KubeRay contains multiple Go modules. See the
+[VS Code Go documentation] for details.
+
+### Automated Tests
+
+Run unit tests with the following command.
+
+```console
+cd kubectl-plugin
+go test ./pkg/... -race -parallel 4
+```
+
+### Manual Tests
+
+Run the plugin commands against a Kubernetes cluster where you have deployed the [KubeRay Operator].
+Here's some example usage.
+
+```console
+❯ kubectl ray --context my-context version
+kubectl ray plugin version: development
+KubeRay operator version: v1.2.2@sha256:cc8ce713f3b4be3c72cca1f63ee78e3733bc7283472ecae367b47a128f7e4478
+
+❯ kubectl ray --context my-context create cluster -n exoplanet portia
+Created Ray Cluster: portia
+
+❯ kubectl ray --context my-context get cluster -n exoplanet
+NAME      NAMESPACE   DESIRED WORKERS   AVAILABLE WORKERS   CPUS   GPUS   TPUS   MEMORY   AGE
+bianca    exoplanet   1                 1                   16     2      0      96Gi     21d
+portia    exoplanet   1                 1                   4      0      0      8Gi      29m
+
+❯ kubectl ray --context my-context delete -n exoplanet raycluster/portia
+Are you sure you want to delete raycluster portia? (y/yes/n/no) y
+Delete raycluster portia
+```
+
+[download-kubectl]: https://kubernetes.io/docs/tasks/tools/install-kubectl/
+[download-go]: https://golang.org/dl/
+[VS Code Go extension]: https://marketplace.visualstudio.com/items?itemName=golang.Go
+[VS Code Go documentation]: https://github.com/golang/vscode-go/blob/master/README.md#setting-up-your-workspace
+[KubeRay Operator]: https://docs.ray.io/en/latest/cluster/kubernetes/index.html

--- a/kubectl-plugin/pkg/cmd/create/create_cluster_test.go
+++ b/kubectl-plugin/pkg/cmd/create/create_cluster_test.go
@@ -104,7 +104,7 @@ func TestRayCreateClusterValidate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.opts.Validate()
 			if tc.expectError != "" {
-				assert.Equal(t, tc.expectError, err.Error())
+				assert.Error(t, err, tc.expectError)
 			} else {
 				assert.Nil(t, err)
 			}

--- a/kubectl-plugin/pkg/cmd/get/get_cluster_test.go
+++ b/kubectl-plugin/pkg/cmd/get/get_cluster_test.go
@@ -133,8 +133,7 @@ func TestRayClusterGetValidate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.opts.Validate()
 			if tc.expectError != "" {
-				assert.Error(t, err)
-				assert.Equal(t, tc.expectError, err.Error())
+				assert.Error(t, err, tc.expectError)
 			} else {
 				assert.NoError(t, err)
 			}

--- a/kubectl-plugin/pkg/cmd/job/job_submit_test.go
+++ b/kubectl-plugin/pkg/cmd/job/job_submit_test.go
@@ -115,7 +115,7 @@ spec:
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.opts.Validate()
 			if tc.expectError != "" {
-				assert.Equal(t, tc.expectError, err.Error())
+				assert.Error(t, err, tc.expectError)
 			} else {
 				assert.Nil(t, err)
 			}

--- a/kubectl-plugin/pkg/cmd/log/log.go
+++ b/kubectl-plugin/pkg/cmd/log/log.go
@@ -183,7 +183,7 @@ func (options *ClusterLogOptions) Validate() error {
 	} else if err != nil {
 		return fmt.Errorf("Error occurred will checking directory: %w", err)
 	} else if !info.IsDir() {
-		return fmt.Errorf("Path is Not a directory. Please input a directory and try again")
+		return fmt.Errorf("Path is not a directory. Please input a directory and try again")
 	}
 
 	return nil

--- a/kubectl-plugin/pkg/cmd/log/log_test.go
+++ b/kubectl-plugin/pkg/cmd/log/log_test.go
@@ -332,7 +332,7 @@ func TestRayClusterLogValidate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.opts.Validate()
 			if tc.expectError != "" {
-				assert.Equal(t, tc.expectError, err.Error())
+				assert.Error(t, err, tc.expectError)
 			} else {
 				if tc.opts.outputDir == "" {
 					assert.Equal(t, tc.opts.ResourceName, tc.opts.outputDir)

--- a/kubectl-plugin/pkg/util/test_utils.go
+++ b/kubectl-plugin/pkg/util/test_utils.go
@@ -1,0 +1,40 @@
+package util
+
+import (
+	"path/filepath"
+	"testing"
+
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+// createTempKubeConfigFile creates a temporary kubeconfig file with the given current context.
+func CreateTempKubeConfigFile(t *testing.T, currentContext string) (string, error) {
+	tmpDir := t.TempDir()
+
+	// Set up fake config for kubeconfig
+	config := &api.Config{
+		Clusters: map[string]*api.Cluster{
+			"test-cluster": {
+				Server:                "https://fake-kubernetes-cluster.example.com",
+				InsecureSkipTLSVerify: true, // For testing purposes
+			},
+		},
+		Contexts: map[string]*api.Context{
+			"my-fake-context": {
+				Cluster:  "my-fake-cluster",
+				AuthInfo: "my-fake-user",
+			},
+		},
+		CurrentContext: currentContext,
+		AuthInfos: map[string]*api.AuthInfo{
+			"my-fake-user": {
+				Token: "", // Empty for testing without authentication
+			},
+		},
+	}
+
+	fakeFile := filepath.Join(tmpDir, ".kubeconfig")
+
+	return fakeFile, clientcmd.WriteToFile(*config, fakeFile)
+}

--- a/ray-operator/DEVELOPMENT.md
+++ b/ray-operator/DEVELOPMENT.md
@@ -7,7 +7,7 @@ This section walks through how to build and test the operator in a running Kuber
 | software | version  |                                                                link |
 |:---------|:--------:|--------------------------------------------------------------------:|
 | kubectl  | v1.23.0+ | [download](https://kubernetes.io/docs/tasks/tools/install-kubectl/) |
-| go       |  v1.20   |                                  [download](https://golang.org/dl/) |
+| go       |  v1.22   |                                  [download](https://golang.org/dl/) |
 | docker   |  19.03+  |                        [download](https://docs.docker.com/install/) |
 
 Alternatively, you can use podman (version 4.5+) instead of docker. See [podman.io](https://podman.io/getting-started/installation) for installation instructions. The Makefile allows you to specify the container engine to use via the `ENGINE` variable. For example, to use podman, you can run `ENGINE=podman make docker-build`.


### PR DESCRIPTION
file that's not at the default path. Right now tests fail if there's a K8s current context set with a command like `kubectl config use-context my-context`.

This change allows tests to regardless of current context.

We also document how to develop the plugin.

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] This PR is not tested :(
